### PR TITLE
Bugfix: Don't normalize color values that are provided by a user to 255.

### DIFF
--- a/illuminate/ledarray.cpp
+++ b/illuminate/ledarray.cpp
@@ -1041,14 +1041,6 @@ void LedArray::setColor(int16_t argc, char ** argv)
       return;
     }
 
-    // Normalize all colors to a mean value of 255
-    uint16_t color_total = 0;
-    for (int color_channel_index = 0; color_channel_index < led_array_interface->color_channel_count; color_channel_index++)
-      color_total += (uint16_t)led_color[color_channel_index];
-
-    for (int color_channel_index = 0; color_channel_index < led_array_interface->color_channel_count; color_channel_index++)
-      led_color[color_channel_index] = (uint8_t) (255.0 * (float)led_color[color_channel_index] / (float)color_total) ;
-
     // Set LED vlaue based on color and brightness
     for (int color_channel_index = 0; color_channel_index < led_array_interface->color_channel_count; color_channel_index++)
       led_value[color_channel_index] = (uint8_t) (((float) led_color[color_channel_index] / UINT8_MAX) * (float) led_brightness);


### PR DESCRIPTION
This kind of normalization makes it really difficult to hit full brightness.

```
Red = 255, blue = 255, green =0
```
becomes 
```
Red = 255/2, blue = 255/2, green=0 or something
```

Maybe you meant to normalize by the "max"?

Anyway, this is really a **breaking** change for us. 

It seems to me that this kind of high level color management should be kept to a different function.

As an application note, we mostly do all this kind of magic in Python and almost never use the serial console directly.