### PR TITLE
Minor fix for the command parser

### DIFF
--- a/illuminate/commandrouting.h
+++ b/illuminate/commandrouting.h
@@ -483,6 +483,9 @@ void CommandRouter::processSerialStream()
             Serial.print(SERIAL_COMMAND_TERMINATOR);
             Serial.print(SERIAL_LINE_ENDING);
           }
+          
+          argument_flag = false;
+          
           break;
         }
       case '.':   // dot SERIAL_DELIMITER


### PR DESCRIPTION
Reset argument_flag after each command (or it will prevent the reset of argument_count, eventually causing a memory leak).