### PR TITLE
bug fix: now correctly initializes global_shutter_state

### DIFF
--- a/illuminate/src/ledarrays/sci.round.cpp
+++ b/illuminate/src/ledarrays/sci.round.cpp
@@ -47,6 +47,9 @@
 #include "../TeensyComparator/TeensyComparator.h"
 #endif
 
+// Global shutter state
+bool global_shutter_state = true;
+
 // Power sensing pin
 const int POWER_SENSE_PIN = 23;
 


### PR DESCRIPTION
global_shutter_state was not defined in sci.round.cpp, so compilation failed.