### PR TITLE
Update sequencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,50 @@ Illuminate was designed to standardize the interface and functionality of LED ar
 10. Press upload to load code onto Teensy. You may need to press the white button on the top of the micro-controller to trigger the upload.
 11. Type command (ex: "bf") and press enter to send
 
-## Commands
-Command help can be accessed by typing "?" into the Arduino terminal.
-
 ## Interfaces
-All commands are sent over a serial (COM) port. This allows interfacing from any program or program language on most systems, as well as through Micro-Manager or other microscopy platforms. There is also a controller library located [here](http://www.github.com/zfphil/illuminate_controller)
+All commands are sent over a serial (COM) port using a default baud rate of `115200`, and otherwise default settings. There are several ways to control these LED Arrays:
+- The Serial Monitor within the [Arduino IDE](https://www.arduino.cc/en/software)
+- The [Micro-Manager](https://micro-manager.org/Micro-Manager_Nightly_Builds) IlluminateLedArray Driver (nightly builds since 2019)
+- MATLAB and python via modules within the [The Illuminate Controller Repository](http://www.github.com/zfphil/illuminate_controller)
+- Any standard serial library within other languages (C++, java, etc.)
+
+## Commands
+Command help can be accessed by typing "?" into the Arduino terminal. These are also copied at the end of this file (see below) for convenience.
+Static patterns may be 
+
+#### Triggering and Sequences
+While patterns may be executed statically using commands such as `bf` (brightfield), `df` (darkfield), or `dpc.t` (DPC Top), this firmware provides a sequencing interface which enables hardware-limited pattern updates as well as triggering support.
+Illuminate supports several pre-defined pattern sequences:
+- `scf`: Scan all LEDs, one at a time
+- `scb`: Scan all brightfield LEDs (within the na set by the `na` command)
+- `scd`: Scan all darkfield LEDs (within the na set by the `na` command)
+- `rdpc`: Scan four half-circle "DPC" patterns (within the na set by the `na` command)
+
+For all patterns, a delay betweenn pattern updates may be set using the first argument (e.g. `scf.500` will provide 500ms delay. Multiple pattern cycles may be kicked off using the second argument (e.g. `scf.0.2` will cycle through two patterns as fast as possible).
+Custom pattern sequences are also supported. See the `ssl`, `ssv`, `pseq`, and `rseq` commands below for more information.
+
+To enable triggering using SMA ports on the side of devices, The `tim` (trigger input mode) and `tom` (trigger output mode) commands can be used.
+The first argument is the trigger number (`0` or `1`), and the second argument is the mode:
+- `-2`: One pulse at the start of the first pattern cycle. Even if multiple pattern cycles are provided (second argument above), only one trigger pulse is sent.
+- `-1`: One pulxe at the start of each pattern sequence
+- `0`: This sequence will not wait for or emit any trigger signals
+- `1`: Emit or wait for one trigger pulse per pattern update.
+- `2`, `3`, `4`, ... `N`: Emit or wait for one trigger pulse per every `N` pattern updates.
+
+Trigger inputs and outputs use the same mode strings. Note that trigger inputs will wait up to the timeout set in `trinputtimeout` before erroring (30s is the default).
+Trigger polarity, pulse width, and short delays may be set via the api described below.
+
+Sending any serial command will halt a sequence (and discard that command, which will need to be re-sent to take effect).
 
 ## Devices
-This project is designed for led arrays which are controlled by a Teensy 3.2 micro-controller. Additional micro-controllers should be easy to support if pins are configured correctly.
+This project is designed for led arrays which are controlled by a Teensy 3.2, Teensy 4.0, or Teensy 4.1 micro-controller. Additional micro-controllers should be easy to support if pins are configured correctly.
 
-#### Currently supported
+#### Currently supported devices
 - Quasi-Dome Illuminator (Waller Lab, UC Berkeley)
 - Direct LED connection array (Waller Lab, UC Berkeley)
-- Target Array (SCI Microscopy)
-
-#### Planned support
-- 32x32 array (Adafruit)
-- (Your LED array here!)
+- sci.round ([SCI Microscopy](https://sci-microscopy.com))
+- sci.dome ([SCI Microscopy](https://sci-microscopy.com))
+- Various custom devices by [SCI Microscopy](https://sci-microscopy.com)
 
 #### Adding New Devices
 New devices are created by adding a new .cpp file to the root directory of the project and providing functions for the LedArrayInterface class. Static variables within this class must also be defined in the cpp file (including LED positions, trigger ports, etc.).
@@ -78,426 +105,500 @@ New devices are created by adding a new .cpp file to the root directory of the p
 ```
 
 ## Contributions
-Pull requests will be reviewed as received!
+Pull requests will be reviewed as received, and are encouraged!
 
 ## API Reference
-
-```
 -----------------------------------
-Command List: 
+Command List:
 -----------------------------------
 COMMAND: 
-? / help
-SYNTAX:?
-DESCRIPTION:
-Display help info
------------------------------------
-COMMAND: 
-info / about
-SYNTAX:about
-DESCRIPTION:
-Displays information about this LED Array
------------------------------------
-COMMAND: 
-reboot / reset
-SYNTAX:reboot
-DESCRIPTION:
-Runs setup routine again, for resetting LED array
------------------------------------
-COMMAND: 
-ver / version
+  about
 SYNTAX:
+  about
 DESCRIPTION:
-Display controller version number
+  Displays information about this device
 -----------------------------------
 COMMAND: 
-ac / autoClear
-SYNTAX:ac --or-- ac.[0/1]
-DESCRIPTION:
-Toggle clearing of array between led updates. Can call with or without options.
------------------------------------
-COMMAND: 
-na / setNa
-SYNTAX:na.[na*100]
-DESCRIPTION:
-Set na used for bf/df/dpc/cdpc patterns
------------------------------------
-COMMAND: 
-sc / setColor
-SYNTAX:sc,[rgbVal] --or-- sc.[rVal].[gVal].[bVal]
-DESCRIPTION:
-Set LED array color
------------------------------------
-COMMAND: 
-sb / setBrightness
-SYNTAX:sb,[rgbVal] --or-- sb.[rVal].[gVal].[bVal]
-DESCRIPTION:
-Set LED array brightness
------------------------------------
-COMMAND: 
-sad / setArrayDistance
-SYNTAX:sad,[dist (mm)]
-DESCRIPTION:
-Set LED array distance
------------------------------------
-COMMAND: 
-l / led
-SYNTAX:ll.[led #].[led #], ...
-DESCRIPTION:
-Turn on a single LED (or multiple LEDs in a list)
------------------------------------
-COMMAND: 
-x / xx
-SYNTAX:x
-DESCRIPTION:
-Clear the LED array.
------------------------------------
-COMMAND: 
-ff / fillArray
-SYNTAX:ff
-DESCRIPTION:
-Fill the LED array with default color.
------------------------------------
-COMMAND: 
-bf / brightfield
-SYNTAX:bf
-DESCRIPTION:
-Display brightfield pattern
------------------------------------
-COMMAND: 
-df / darkfield
-SYNTAX:df
-DESCRIPTION:
-Display darkfield pattern
------------------------------------
-COMMAND: 
-dpc / halfCircle
-SYNTAX:dpc.[t/b/l/r] --or-- dpc.[top/bottom/left/right] --or-- dpc (will raw first pattern)
-DESCRIPTION:
-Illuminate half-circle (DPC) pattern
------------------------------------
-COMMAND: 
-cdpc / colorDpc
-SYNTAX:cdpc.[rVal],[gVal].[bVal]) --or-- cdpc.[rgbVal]) --or-- cdpc
-DESCRIPTION:
-Illuminate color DPC (cDPC) pattern
------------------------------------
-COMMAND: 
-an / annulus
-SYNTAX:an.[minNA*100].[maxNA*100]
-DESCRIPTION:
-Display annulus pattern set by min/max na
------------------------------------
-COMMAND: 
-ha / halfAnnulus
-SYNTAX:ha.[type].[minNA*100].[maxNA*100]
-DESCRIPTION:
-Illuminate half annulus
------------------------------------
-COMMAND: 
-dq / drawQuadrant
-SYNTAX:dq --or-- dq.[rVal].[gVal].[bVal]
-DESCRIPTION:
-Draws single quadrant
------------------------------------
-COMMAND: 
-cdf / Color Darkfield
-SYNTAX:cdf.[rVal].[gVal].[bVal]) --or-- cdf.[rgbVal]) --or-- cdf
-DESCRIPTION:
-Draws color darkfield pattern
------------------------------------
-COMMAND: 
-ndpc / navigator
-SYNTAX:ndpc.[t/b/l/r] --or-- ndpc.[top/bottom/left/right]
-DESCRIPTION:
-Illuminate half-circle (DPC) pattern with navigator
------------------------------------
-COMMAND: 
-scf / scanFull
-SYNTAX:scf,[delay_ms]
-DESCRIPTION:
-Scan all active LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.
------------------------------------
-COMMAND: 
-scb / scanBrightfield
-SYNTAX:scb,[delay_ms]
-DESCRIPTION:
-Scan all brightfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.
------------------------------------
-COMMAND: 
-ssl / setSeqLength
-SYNTAX:ssl,[Sequence length]
-DESCRIPTION:
-Set sequence length in terms of independent patterns
------------------------------------
-COMMAND: 
-ssv / setSeqValue
-SYNTAX:ssl.[# Number of LEDs], [LED number 0], [LED number 1]], [LED number 2], ...
-DESCRIPTION:
-Set sequence value
------------------------------------
-COMMAND: 
-rseq / runSequence
-SYNTAX:rseq,[Delay between each pattern in ms].[number of times to repeat pattern].[trigger output 0 mode].[trigger output 1 mode].[trigger input 0 mode].[trigger input 1 mode]
-DESCRIPTION:
-Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.
------------------------------------
-COMMAND: 
-rseqf / runSequenceFast
-SYNTAX:rseqf,[Delay between each pattern in ms].[trigger mode for index 0].[trigger mode for index 1].[trigger mode for index 2] 
-DESCRIPTION:
-Runs sequence with specified delay between each update. Uses parallel digital IO to acheive very fast speeds (single us). Only available on certain LED arrays.
------------------------------------
-COMMAND: 
-pseq / printSeq
-SYNTAX:pseq
-DESCRIPTION:
-Prints sequence values to the terminal
------------------------------------
-COMMAND: 
-pseql / printSeqLength
-SYNTAX:pseql
-DESCRIPTION:
-Prints sequence length to the terminal
------------------------------------
-COMMAND: 
-sseq / stepSequence
-SYNTAX:sseq.[trigger output mode for index 0].[trigger output mode for index 1],
-DESCRIPTION:
-Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.
------------------------------------
-COMMAND: 
-reseq / resetSeq
-SYNTAX:reseq
-DESCRIPTION:
-Resets sequence index to start
------------------------------------
-COMMAND: 
-ssbd / setSeqBitDepth
-SYNTAX:ssbd.1 --or-- ssbd.8 --or-- ssbd.16.
-DESCRIPTION:
-Sets bit depth of sequence values (1, 8, or 16)
------------------------------------
-COMMAND: 
-ssz / setSeqZeros
-SYNTAX:ssz.10
-DESCRIPTION:
-Sets a range of the sequence entries to zero, starting at the current sequence index
------------------------------------
-COMMAND: 
-tr / trig
-SYNTAX:tr.[trigger index]
-DESCRIPTION:
-Output TTL trigger pulse to camera
------------------------------------
-COMMAND: 
-trs / trigSetup
-SYNTAX:trs.[trigger index].[trigger pin index].['trigger delay between H and L pulses]
-DESCRIPTION:
-Set up hardware (TTL) triggering
------------------------------------
-COMMAND: 
-trt / trigTest
-SYNTAX:trt.[trigger input index]
-DESCRIPTION:
-Waits for trigger pulses on the defined channel
------------------------------------
-COMMAND: 
-ch / drawChannel
-SYNTAX:dc.[led#]
-DESCRIPTION:
-Draw LED by hardware channel (use for debugging)
------------------------------------
-COMMAND: 
-dbg / debug
-SYNTAX:dbg.[command router debug].[LED array (generic) debug].[LED interface debug] --or-- dbg (toggles all between level 1 or 0)
-DESCRIPTION:
-Toggle debug flag. Can call with or without options.
------------------------------------
-COMMAND: 
-spo / set_pin_order
-SYNTAX:spo.[rChan].[gChan].[bChan] --or-- spo.[led#].[rChan].[gChan].[bChan]
-DESCRIPTION:
-Sets pin order (R/G/B) for setup purposes. Also can flip individual leds by passing fourth argument.
------------------------------------
-COMMAND: 
-delay / wait
-SYNTAX:delay.[length of time in ms]
-DESCRIPTION:
-Simply puts the device in a loop for the amount of time in ms
------------------------------------
-COMMAND: 
-smc / setMaxCurrent
-SYNTAX:smc.[current limit in amps]
-DESCRIPTION:
-Sets max current in amps
------------------------------------
-COMMAND: 
-smce / set_max_current_enforcement
-SYNTAX:smce.[0, 1]
-DESCRIPTION:
-Sets whether or not max current limit is enforced (0 is no, all other values are yes)
------------------------------------
-COMMAND: 
-pvals / printVals
-SYNTAX:pvals
-DESCRIPTION:
-Print led values for software interface
------------------------------------
-COMMAND: 
-pp / printParams
-SYNTAX:pp
-DESCRIPTION:
-Prints system parameters such as NA, LED Array z-distance, etc. in the format of a json file
------------------------------------
-COMMAND: 
-pledpos / printLedPositions
-SYNTAX:pledpos
-DESCRIPTION:
-Prints the positions of each LED in cartesian coordinates.
------------------------------------
-COMMAND: 
-pledposna / printLedPositionsNa
-SYNTAX:pledposna
-DESCRIPTION:
-Prints the positions of each LED in NA coordinates (NA_x, NA_y, NA_distance
------------------------------------
-COMMAND: 
-disco / party
-SYNTAX:disco.[Number of LEDs in pattern]
-DESCRIPTION:
-Illuminate a random color pattern of LEDs
------------------------------------
-COMMAND: 
-demo / runDemo
-SYNTAX:demo
-DESCRIPTION:
-Runs a demo routine to show what the array can do.
------------------------------------
-COMMAND: 
-water / waterDrop
-SYNTAX:water
-DESCRIPTION:
-Water drop demo
------------------------------------
-COMMAND: 
-setsn / setSerialNumber
+  reset
 SYNTAX:
+  reboot
 DESCRIPTION:
-Sets device serial number in EEPROM (DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+  Runs setup routine again, for resetting LED array
 -----------------------------------
 COMMAND: 
-setpn / set_part_number
+  version
 SYNTAX:
+  version
 DESCRIPTION:
-Sets device part number in EEPROM (DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+  Display controller version number
 -----------------------------------
 COMMAND: 
-rdpc / runDpc
-SYNTAX:rdpc,[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]
+  license
+SYNTAX:
+  license
 DESCRIPTION:
-Runs a DPC sequence with specified delay between each update. If update speed is too fast, a warning message will print.
+  Display software license for firmware residing on this teensy
 -----------------------------------
 COMMAND: 
-rfpm / runFpm
-SYNTAX:rfpm,[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[Maximum NA * 100 (e.g. 0.25NA would be 25].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]
+  ?
+SYNTAX:
+  license
 DESCRIPTION:
-Runs a FPM sequence with specified delay between each update. If update speed is too fast, a warning message will print.
+  Display human-readable help information.
 -----------------------------------
 COMMAND: 
-sbr / set_sclk_baud_rate
-SYNTAX:sbr.1000000
+  store
+SYNTAX:
+  store
 DESCRIPTION:
-Sets SPI baud rate for TLC5955 Chips in Hz (baud)
+  Store device parameters
 -----------------------------------
 COMMAND: 
-sgs / set_gsclk_frequency
-SYNTAX:sgs.1000000
+  recall
+SYNTAX:
+  recall
 DESCRIPTION:
-Sets GSCLK frequency in Hz
+  Recall stored device parameters
 -----------------------------------
 COMMAND: 
-human / setModeHuman
-SYNTAX:human
+  autoload
+SYNTAX:
+  autoload [or] autoload.1
 DESCRIPTION:
-Sets command mode to human-readable
+  Toggle/set whether previously stored settings are loaded on power-up. Value is persistant.
 -----------------------------------
 COMMAND: 
-machine / setModeMachine
-SYNTAX:machine
+  ac
+SYNTAX:
+  ac --or-- ac.[0/1]
 DESCRIPTION:
-Sets command mode to machine-readable
+  Toggle clearing of array between led updates. Calling without options toggles the state.
 -----------------------------------
 COMMAND: 
-pwrc / isPowerSourceConnected
-SYNTAX:pwrc
+  na
+SYNTAX:
+  na.[na*100]
 DESCRIPTION:
-Gets the state of the power source, if this device has the hardware to do so.
+  Set na used for bf/df/dpc/cdpc patterns
 -----------------------------------
 COMMAND: 
-pwrs / togglePowerSourceSensing
-SYNTAX:pwrs
+  nai
+SYNTAX:
+  nai.20
 DESCRIPTION:
-Toggle power source sensing on or off.
+  Sets the inner NA. (nai.20 sets an inner NA of 0.20)  Respected by bf, dpc, and rdpc commands. Default is 0
 -----------------------------------
 COMMAND: 
-pwrv / printPowerSourceVoltage
-SYNTAX:pwrv
+  sc
+SYNTAX:
+  sc.[`red` or `green` or `blue` or `white`] --or-- sc.[red_value].[green_value].[blue_value].
 DESCRIPTION:
-Print power sourve voltage.
+  Set LED array color balance (RGB arrays only). Note values are normalized to current brightness (set by the `sb` command)
 -----------------------------------
 COMMAND: 
-nai / setInnerNa
-SYNTAX:nai.20
+  ssc
+SYNTAX:
+  ssc.[channel index].[color]
 DESCRIPTION:
-Sets the inner NA. (nai.20 sets an inner NA of 0.20)  Respected by bf, dpc, and rdpc commands. Default is 0
+  Set single color channel by index
 -----------------------------------
 COMMAND: 
-trinputtimeout / triggerInputTimeout
-SYNTAX:trinputtimeout.10
+  sb
+SYNTAX:
+  sb.[rgbVal] --or-- sb.[rVal].[gVal].[bVal]
 DESCRIPTION:
-Sets the trigger input timeout in seconds. Default is 3600
+  Set LED array brightness
 -----------------------------------
 COMMAND: 
-troutputpulsewidth / triggerOutputPulseWidth
-SYNTAX:troutputpulsewidth.1000
+  sad
+SYNTAX:
+  sad.[dist (mm)]
 DESCRIPTION:
-Sets the trigger pulse width in microseconds, default is 1000.
+  Set LED array distance
 -----------------------------------
 COMMAND: 
-trinputpolarity / triggerInputPolarity
-SYNTAX:trinputpolarity.1
+  l
+SYNTAX:
+  l.[led #].[led #], ...
 DESCRIPTION:
-Sets the trigger input polarity. 1=active high, 0=active low. Default is 1.
+  Turn on a single LED (or multiple LEDs in a list)
 -----------------------------------
 COMMAND: 
-troutputpolarity / triggerOutputPolarity
-SYNTAX:troutputpolarity.1
+  x
+SYNTAX:
+  x
 DESCRIPTION:
-Sets the trigger output polarity. 1=active high, 0=active low. Default is 1.
+  Clear the LED array.
 -----------------------------------
 COMMAND: 
-troutputdelay / triggerOutputDelay
-SYNTAX:troutputdelay.0
+  gs
+SYNTAX:
+  gs.0 --or-- gs.1
 DESCRIPTION:
-Sets the trigger delay in microseconds. Default is zero.
+  Set the global shutter state to open (1) or closed (0), maintaining all other settings
 -----------------------------------
 COMMAND: 
-trinputpin / triggerInputPin
-SYNTAX:trinputpin
+  ff
+SYNTAX:
+  ff
 DESCRIPTION:
-Returns the Teensy pin of the trigger inputsignal. Used only for debugging.
+  Fill the LED array with default color.
 -----------------------------------
 COMMAND: 
-troutputpin / triggerOutputPin
-SYNTAX:troutputpin
+  bf
+SYNTAX:
+  bf
 DESCRIPTION:
-Returns the Teensy pin of the trigger outputsignal. Used only for debugging.
+  Display brightfield pattern
 -----------------------------------
 COMMAND: 
-cos / cosineFactor
-SYNTAX:cos.2
+  df
+SYNTAX:
+  df
 DESCRIPTION:
-Returns or sets the cosine factor, used to scale LED intensity (so outer LEDs are brighter). Input is cos.[integer cosine factor]
+  Display darkfield pattern
+-----------------------------------
+COMMAND: 
+  dpc
+SYNTAX:
+  dpc.[t/b/l/r] --or-- dpc.[top/bottom/left/right] --or-- dpc (will raw first pattern)
+DESCRIPTION:
+  Illuminate half-circle (DPC) pattern
+-----------------------------------
+COMMAND: 
+  cdpc
+SYNTAX:
+  cdpc.[rVal].[gVal].[bVal]) --or-- cdpc.[rgbVal]) --or-- cdpc
+DESCRIPTION:
+  Illuminate color DPC (cDPC) pattern
+-----------------------------------
+COMMAND: 
+  an
+SYNTAX:
+  an.[minNA*100].[maxNA*100]
+DESCRIPTION:
+  Display annulus pattern set by min/max na
+-----------------------------------
+COMMAND: 
+  ha
+SYNTAX:
+  ha.[type].[minNA*100].[maxNA*100]
+DESCRIPTION:
+  Illuminate half annulus
+-----------------------------------
+COMMAND: 
+  dq
+SYNTAX:
+  dq --or-- dq.[quadrant index]
+DESCRIPTION:
+  Draws single quadrant
+-----------------------------------
+COMMAND: 
+  cdf
+SYNTAX:
+  cdf.[rVal].[gVal].[bVal]) --or-- cdf.[rgbVal]) --or-- cdf
+DESCRIPTION:
+  Draws color darkfield pattern
+-----------------------------------
+COMMAND: 
+  scf
+SYNTAX:
+  scf.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]
+DESCRIPTION:
+  Scan all active LEDs. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.
+-----------------------------------
+COMMAND: 
+  scb
+SYNTAX:
+  scb.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]
+DESCRIPTION:
+  Scan all brightfield LEDs. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.
+-----------------------------------
+COMMAND: 
+  scd
+SYNTAX:
+  scb.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]
+DESCRIPTION:
+  Scan all darkfield LEDs. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.
+-----------------------------------
+COMMAND: 
+  ssl
+SYNTAX:
+  ssl.[Sequence length]
+DESCRIPTION:
+  Set sequence length, or the number of patterns to be cycles through (not the number of leds per pattern).
+-----------------------------------
+COMMAND: 
+  ssv
+SYNTAX:
+  ssl.[# Number of LEDs], [LED number 0], [LED number 1]], [LED number 2], ...
+DESCRIPTION:
+  Set sequence value
+-----------------------------------
+COMMAND: 
+  rseq
+SYNTAX:
+  rseq.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]
+DESCRIPTION:
+  Runs sequence with specified delay between each update. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.
+-----------------------------------
+COMMAND: 
+  pseq
+SYNTAX:
+  pseq
+DESCRIPTION:
+  Prints sequence values to the terminal
+-----------------------------------
+COMMAND: 
+  sseq
+SYNTAX:
+  sseq
+DESCRIPTION:
+  Manually step through a sequence, incrementing the current index. May emit or wait for trigger signals depending on trigger settings.
+-----------------------------------
+COMMAND: 
+  xseq
+SYNTAX:
+  xseq
+DESCRIPTION:
+  Resets sequence index to the first value, leaving the sequence unchanged.
+-----------------------------------
+COMMAND: 
+  rdpc
+SYNTAX:
+  rdpc.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]
+DESCRIPTION:
+  Runs a DPC sequence with specified delay between each update. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.
+-----------------------------------
+COMMAND: 
+  tr
+SYNTAX:
+  tr.[trigger index]
+DESCRIPTION:
+  Output TTL trigger pulse to camera
+-----------------------------------
+COMMAND: 
+  trs
+SYNTAX:
+  trs.[trigger index].[trigger pin index].['trigger delay between H and L pulses]
+DESCRIPTION:
+  Set up hardware (TTL) triggering
+-----------------------------------
+COMMAND: 
+  trt
+SYNTAX:
+  trt.[trigger input index]
+DESCRIPTION:
+  Waits for trigger pulses on the defined channel
+-----------------------------------
+COMMAND: 
+  ch
+SYNTAX:
+  dc.[led#]
+DESCRIPTION:
+  Draw LED by hardware channel (use for debugging)
+-----------------------------------
+COMMAND: 
+  debug
+SYNTAX:
+  dbg.[command router debug].[LED array (generic) debug].[LED interface debug] --or-- dbg (toggles all between level 1 or 0)
+DESCRIPTION:
+  Toggle debug flag. Can call with or without options.
+-----------------------------------
+COMMAND: 
+  spo
+SYNTAX:
+  spo.[rChan].[gChan].[bChan] --or-- spo.[led#].[rChan].[gChan].[bChan]
+DESCRIPTION:
+  Sets pin order (R/G/B) for setup purposes. Also can flip individual leds by passing fourth argument.
+-----------------------------------
+COMMAND: 
+  delay
+SYNTAX:
+  delay.[length of time in ms]
+DESCRIPTION:
+  Simply puts the device in a loop for the amount of time in ms
+-----------------------------------
+COMMAND: 
+  mc
+SYNTAX:
+  mc.[current limit in amps]
+DESCRIPTION:
+  Sets/Gets max current in amps
+-----------------------------------
+COMMAND: 
+  mce
+SYNTAX:
+  mce.[0, 1]
+DESCRIPTION:
+  Sets/Gets whether or not max current limit is enforced (0 is no, all other values are yes)
+-----------------------------------
+COMMAND: 
+  pvals
+SYNTAX:
+  pvals
+DESCRIPTION:
+  Print led values for software interface
+-----------------------------------
+COMMAND: 
+  pledpos
+SYNTAX:
+  pledpos
+DESCRIPTION:
+  Prints the positions of each LED in cartesian coordinates.
+-----------------------------------
+COMMAND: 
+  pprops
+SYNTAX:
+  pprops
+DESCRIPTION:
+  Prints system parameters such as NA, LED Array z-distance, etc. in the format of a json file
+-----------------------------------
+COMMAND: 
+  pledposna
+SYNTAX:
+  pledposna
+DESCRIPTION:
+  Prints the positions of each LED in NA coordinates (NA_x, NA_y, NA_distance
+-----------------------------------
+COMMAND: 
+  disco
+SYNTAX:
+  disco.[Number of LEDs in pattern]
+DESCRIPTION:
+  Illuminate a random color pattern of LEDs
+-----------------------------------
+COMMAND: 
+  demo
+SYNTAX:
+  demo
+DESCRIPTION:
+  Runs a demo routine to show what the array can do.
+-----------------------------------
+COMMAND: 
+  water
+SYNTAX:
+  water
+DESCRIPTION:
+  Water drop demo
+-----------------------------------
+COMMAND: 
+  sn
+SYNTAX:
+  sn
+DESCRIPTION:
+  Gets device serial number
+-----------------------------------
+COMMAND: 
+  pn
+SYNTAX:
+  pn
+DESCRIPTION:
+  Gets device part number
+-----------------------------------
+COMMAND: 
+  sbr
+SYNTAX:
+  sbr.1000000
+DESCRIPTION:
+  Sets SPI baud rate for TLC5955 Chips in Hz (baud)
+-----------------------------------
+COMMAND: 
+  sgs
+SYNTAX:
+  sgs.1000000
+DESCRIPTION:
+  Sets GSCLK frequency in Hz
+-----------------------------------
+COMMAND: 
+  human
+SYNTAX:
+  human
+DESCRIPTION:
+  Sets command mode to human-readable
+-----------------------------------
+COMMAND: 
+  machine
+SYNTAX:
+  machine
+DESCRIPTION:
+  Sets command mode to machine-readable
+-----------------------------------
+COMMAND: 
+  pwrs
+SYNTAX:
+  pwrs
+DESCRIPTION:
+  Toggle power source sensing on or off.
+-----------------------------------
+COMMAND: 
+  pwrv
+SYNTAX:
+  pwrv
+DESCRIPTION:
+  Print power sourve voltage.
+-----------------------------------
+COMMAND: 
+  trinputtimeout
+SYNTAX:
+  trinputtimeout.10
+DESCRIPTION:
+  Sets the trigger input timeout in seconds. Default is 60 (60s).
+-----------------------------------
+COMMAND: 
+  troutputpulsewidth
+SYNTAX:
+  troutputpulsewidth.1000
+DESCRIPTION:
+  Sets the trigger pulse width in microseconds, default is 1000.
+-----------------------------------
+COMMAND: 
+  trinputpolarity
+SYNTAX:
+  trinputpolarity.1
+DESCRIPTION:
+  Sets the trigger input polarity. 1=active high, 0=active low. Default is 1.
+-----------------------------------
+COMMAND: 
+  troutputpolarity
+SYNTAX:
+  troutputpolarity.1
+DESCRIPTION:
+  Sets the trigger output polarity. 1=active high, 0=active low. Default is 1.
+-----------------------------------
+COMMAND: 
+  troutputdelay
+SYNTAX:
+  troutputdelay.0
+DESCRIPTION:
+  Sets the trigger delay in microseconds. Default is zero.
+-----------------------------------
+COMMAND: 
+  trinputpin
+SYNTAX:
+  trinputpin
+DESCRIPTION:
+  Returns the Teensy pin of the trigger inputsignal. Used only for debugging.
+-----------------------------------
+COMMAND: 
+  troutputpin
+SYNTAX:
+  troutputpin
+DESCRIPTION:
+  Returns the Teensy pin of the trigger outputsignal. Used only for debugging.
+-----------------------------------
+COMMAND: 
+  cos
+SYNTAX:
+  cos.2
+DESCRIPTION:
+  Returns or sets the cosine factor, used to scale LED intensity (so outer LEDs are brighter). Input is cos.[integer cosine factor]
+-----------------------------------
+COMMAND: 
+  hwinit
+SYNTAX:
+  hwinit.[sn].[pn]
+DESCRIPTION:
+  Manufacturer hardware initialization. Modifies persistant settings - do not use unless you know what you're doing.
 -----------------------------------
 ```

--- a/illuminate/commandconstants.h
+++ b/illuminate/commandconstants.h
@@ -67,10 +67,10 @@ int scan_full_func(CommandRouter *cmd, int argc, const char **argv);
 int scan_brightfield_func(CommandRouter *cmd, int argc, const char **argv);
 int scan_darkfield_func(CommandRouter *cmd, int argc, const char **argv);
 
-int set_sequence_length_func(CommandRouter *cmd, int argc, const char **argv);
-int set_sequence_value_func(CommandRouter *cmd, int argc, const char **argv);
+int set_custom_sequence_length_func(CommandRouter *cmd, int argc, const char **argv);
+int set_custom_sequence_value_func(CommandRouter *cmd, int argc, const char **argv);
 int run_sequence_func(CommandRouter *cmd, int argc, const char **argv);
-int print_sequence_func(CommandRouter *cmd, int argc, const char **argv);
+int print_custom_sequence_func(CommandRouter *cmd, int argc, const char **argv);
 int step_sequence_func(CommandRouter *cmd, int argc, const char **argv);
 int restart_sequence_func(CommandRouter *cmd, int argc, const char **argv);
 
@@ -159,20 +159,20 @@ command_item_t command_list[] = {
   {"cdf", "Draws color darkfield pattern", "cdf.[rVal].[gVal].[bVal]) --or-- cdf.[rgbVal]) --or-- cdf", color_darkfield_func},
 
   // Single LED Scanning
-  {"scf",  "Scan all active LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scf.[delay_ms]", scan_full_func},
-  {"scb",  "Scan all brightfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scb.[delay_ms]", scan_brightfield_func},
-  {"scd",  "Scan all darkfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scb.[delay_ms]", scan_darkfield_func},
+  {"scf",  "Scan all active LEDs. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.", "scf.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]", scan_full_func},
+  {"scb",  "Scan all brightfield LEDs. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.", "scb.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]", scan_brightfield_func},
+  {"scd",  "Scan all darkfield LEDs. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.", "scb.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]", scan_darkfield_func},
 
   // Custom Sequence Scanning
-  {"ssl",   "Set sequence length in terms of independent patterns", "ssl.[Sequence length]", set_sequence_length_func},
-  {"ssv",   "Set sequence value", "ssl.[# Number of LEDs], [LED number 0], [LED number 1]], [LED number 2], ...", set_sequence_value_func},
-  {"rseq",  "Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.", "rseq.[Delay between each pattern in ms].[number of times to repeat pattern].[trigger output 0 mode].[trigger input 0 mode].[trigger output 1 mode].[trigger input 1 mode]", run_sequence_func},
-  {"pseq",  "Prints sequence values to the terminal", "pseq", print_sequence_func},
-  {"sseq",  "Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.", "sseq.[trigger output mode for index 0].[trigger output mode for index 1]", step_sequence_func},
-  {"xseq",  "Sets sequence index to start", "xseq", restart_sequence_func},
+  {"ssl",   "Set sequence length, or the number of patterns to be cycles through (not the number of leds per pattern).", "ssl.[Sequence length]", set_custom_sequence_length_func},
+  {"ssv",   "Set sequence value", "ssl.[# Number of LEDs], [LED number 0], [LED number 1]], [LED number 2], ...", set_custom_sequence_value_func},
+  {"rseq",  "Runs sequence with specified delay between each update. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.", "rseq.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]", run_sequence_func},
+  {"pseq",  "Prints sequence values to the terminal", "pseq", print_custom_sequence_func},
+  {"sseq",  "Manually step through a sequence, incrementing the current index. May emit or wait for trigger signals depending on trigger settings.", "sseq", step_sequence_func},
+  {"xseq",  "Resets sequence index to the first value, leaving the sequence unchanged.", "xseq", restart_sequence_func},
 
   // Pre-defined sequences
-  {"rdpc", "Runs a DPC sequence with specified delay between each update. If update speed is too fast, a warning message will print.", "rdpc.[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]", run_dpc_func},
+  {"rdpc", "Runs a DPC sequence with specified delay between each update. May emit or wait for trigger signals depending on trigger settings. If update speed is too fast, a warning message will print.", "rdpc.[(Optional - default=0) Delay between each pattern in ms].[(Optional - default=1) Number of times to execute sequence]", run_dpc_func},
   
   // Debugging, Low-level Access, etc.
   {"tr",    "Output TTL trigger pulse to camera", "tr.[trigger index]", trigger_func},

--- a/illuminate/commandconstants.h
+++ b/illuminate/commandconstants.h
@@ -137,10 +137,10 @@ command_item_t command_list[] = {
   {"ac", "Toggle clearing of array between led updates. Calling without options toggles the state.", "ac --or-- ac.[0/1]", autoclear_func},
   {"na", "Set na used for bf/df/dpc/cdpc patterns", "na.[na*100]", na_func},
   {"nai", "Sets the inner NA. (nai.20 sets an inner NA of 0.20)  Respected by bf, dpc, and rdpc commands. Default is 0", "nai.20", na_inner_func},
-  {"sc", "Set LED array color balance (RGB arrays only). Note values are normalized to current brightness (set by the `sb` command)", "sc,[`red` or `green` or `blue` or `white`] --or-- sc.[red_value].[green_value].[blue_value].", color_func},
+  {"sc", "Set LED array color balance (RGB arrays only). Note values are normalized to current brightness (set by the `sb` command)", "sc.[`red` or `green` or `blue` or `white`] --or-- sc.[red_value].[green_value].[blue_value].", color_func},
   {"ssc", "Set single color channel by index", "ssc.[channel index].[color]", set_single_color_func},
-  {"sb", "Set LED array brightness", "sb,[rgbVal] --or-- sb.[rVal].[gVal].[bVal]", brightness_func},
-  {"sad", "Set LED array distance", "sad,[dist (mm)]", array_distance_func},
+  {"sb", "Set LED array brightness", "sb.[rgbVal] --or-- sb.[rVal].[gVal].[bVal]", brightness_func},
+  {"sad", "Set LED array distance", "sad.[dist (mm)]", array_distance_func},
 
   // Single (or multiple) LED Display
   {"l", "Turn on a single LED (or multiple LEDs in a list)", "l.[led #].[led #], ...", set_led_func},
@@ -152,27 +152,27 @@ command_item_t command_list[] = {
   {"bf", "Display brightfield pattern", "bf", brightfield_func},
   {"df", "Display darkfield pattern", "df", darkfield_func},
   {"dpc", "Illuminate half-circle (DPC) pattern", "dpc.[t/b/l/r] --or-- dpc.[top/bottom/left/right] --or-- dpc (will raw first pattern)", dpc_func},
-  {"cdpc", "Illuminate color DPC (cDPC) pattern", "cdpc.[rVal],[gVal].[bVal]) --or-- cdpc.[rgbVal]) --or-- cdpc", cdpc_func},
+  {"cdpc", "Illuminate color DPC (cDPC) pattern", "cdpc.[rVal].[gVal].[bVal]) --or-- cdpc.[rgbVal]) --or-- cdpc", cdpc_func},
   {"an", "Display annulus pattern set by min/max na", "an.[minNA*100].[maxNA*100]", annulus_func},
   {"ha", "Illuminate half annulus", "ha.[type].[minNA*100].[maxNA*100]", half_annulus_func},
   {"dq", "Draws single quadrant", "dq --or-- dq.[quadrant index]", quadrant_func},
   {"cdf", "Draws color darkfield pattern", "cdf.[rVal].[gVal].[bVal]) --or-- cdf.[rgbVal]) --or-- cdf", color_darkfield_func},
 
   // Single LED Scanning
-  {"scf",  "Scan all active LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scf,[delay_ms]", scan_full_func},
-  {"scb",  "Scan all brightfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scb,[delay_ms]", scan_brightfield_func},
-  {"scd",  "Scan all darkfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scb,[delay_ms]", scan_darkfield_func},
+  {"scf",  "Scan all active LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scf.[delay_ms]", scan_full_func},
+  {"scb",  "Scan all brightfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scb.[delay_ms]", scan_brightfield_func},
+  {"scd",  "Scan all darkfield LEDs. Sends trigger pulse in between images. Outputs LED list to serial terminal.", "scb.[delay_ms]", scan_darkfield_func},
 
   // Custom Sequence Scanning
-  {"ssl",   "Set sequence length in terms of independent patterns", "ssl,[Sequence length]", set_sequence_length_func},
+  {"ssl",   "Set sequence length in terms of independent patterns", "ssl.[Sequence length]", set_sequence_length_func},
   {"ssv",   "Set sequence value", "ssl.[# Number of LEDs], [LED number 0], [LED number 1]], [LED number 2], ...", set_sequence_value_func},
-  {"rseq",  "Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.", "rseq,[Delay between each pattern in ms].[number of times to repeat pattern].[trigger output 0 mode].[trigger input 0 mode].[trigger output 1 mode].[trigger input 1 mode]", run_sequence_func},
+  {"rseq",  "Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.", "rseq.[Delay between each pattern in ms].[number of times to repeat pattern].[trigger output 0 mode].[trigger input 0 mode].[trigger output 1 mode].[trigger input 1 mode]", run_sequence_func},
   {"pseq",  "Prints sequence values to the terminal", "pseq", print_sequence_func},
   {"sseq",  "Runs sequence with specified delay between each update. If update speed is too fast, a :( is shown on the LED array.", "sseq.[trigger output mode for index 0].[trigger output mode for index 1]", step_sequence_func},
   {"xseq",  "Sets sequence index to start", "xseq", restart_sequence_func},
 
   // Pre-defined sequences
-  {"rdpc", "Runs a DPC sequence with specified delay between each update. If update speed is too fast, a warning message will print.", "rdpc,[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]", run_dpc_func},
+  {"rdpc", "Runs a DPC sequence with specified delay between each update. If update speed is too fast, a warning message will print.", "rdpc.[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]", run_dpc_func},
   
   // Debugging, Low-level Access, etc.
   {"tr",    "Output TTL trigger pulse to camera", "tr.[trigger index]", trigger_func},

--- a/illuminate/commandconstants.h
+++ b/illuminate/commandconstants.h
@@ -96,7 +96,6 @@ int water_func(CommandRouter *cmd, int argc, const char **argv);
 int get_sn_func(CommandRouter *cmd, int argc, const char **argv);
 int get_pn_func(CommandRouter *cmd, int argc, const char **argv);
 
-int run_fpm_func(CommandRouter *cmd, int argc, const char **argv);
 int run_dpc_func(CommandRouter *cmd, int argc, const char **argv);
 
 int set_baud_rate_func(CommandRouter *cmd, int argc, const char **argv);
@@ -174,8 +173,7 @@ command_item_t command_list[] = {
 
   // Pre-defined sequences
   {"rdpc", "Runs a DPC sequence with specified delay between each update. If update speed is too fast, a warning message will print.", "rdpc,[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]", run_dpc_func},
-  {"rfpm", "Runs a FPM sequence with specified delay between each update. If update speed is too fast, a warning message will print.", "rfpm,[Delay between each pattern in ms (can be zero)].[Number of acquisitions].[Maximum NA * 100 (e.g. 0.25NA would be 25].[trigger output mode for trigger output 0].[trigger input mode for trigger input 0].[trigger output mode for trigger output 1].[trigger input mode for trigger input 1]", run_fpm_func},
-
+  
   // Debugging, Low-level Access, etc.
   {"tr",    "Output TTL trigger pulse to camera", "tr.[trigger index]", trigger_func},
   {"trs",   "Set up hardware (TTL) triggering", "trs.[trigger index].[trigger pin index].['trigger delay between H and L pulses]", trigger_setup_func},

--- a/illuminate/constants.h
+++ b/illuminate/constants.h
@@ -60,9 +60,9 @@ static const char SERIAL_DELIMITER[] = ".";
 #define TRIGGER_OUTPUT_POLARITY_DEFAULT 1
 
 // Misc constants
-#define MIN_SEQUENCE_DELAY 5  // Min deblur pattern delay in ms (set by hardware)
+#define MIN_SEQUENCE_DELAY 5      // Min deblur pattern delay in ms (set by hardware)
 #define MIN_SEQUENCE_DELAY_FAST 2 // Min deblur pattern delay for fast sequence in us (set by hardware)
-#define DELAY_MAX 2000        // Global maximum amount to wait inside loop
+#define MAX_SEQUENCE_DELAY 2000   // Global maximum amount to wait inside a sequence loop
 #define INVALID_NA -2000.0    // Rep```resents an invalid NA
 
 // Command mode constants

--- a/illuminate/illuminate.h
+++ b/illuminate/illuminate.h
@@ -34,7 +34,7 @@
 #ifndef ILLUMINATE_H
 #define ILLUMINATE_H
 
-#define VERSION 2.28
+#define VERSION 2.30
 
 // This file allows the user to define which LED array interface is used. This should be set before compilation.
 // The value these are set to does not matter - only that they are defined.

--- a/illuminate/illuminate.ino
+++ b/illuminate/illuminate.ino
@@ -8,7 +8,7 @@
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
       Redistributions of source code must retain the above copyright
-      notice, this list of conditioset_sequence_value_funcns and the following disclaimer.
+      notice, this list of conditioset_custom_sequence_value_funcns and the following disclaimer.
       Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
@@ -134,16 +134,16 @@ int half_annulus_func(CommandRouter *cmd, int argc, const char **argv){ return l
 int quadrant_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.draw_quadrant(argc, (char * *) argv); }
 int color_darkfield_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.draw_color_darkfield(argc, (char * *) argv); }
 
-int scan_full_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.scan_all_leds(argc, (char * *) argv); }
-int scan_brightfield_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.scan_brightfield_leds(argc, (char * *) argv); }
-int scan_darkfield_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.scan_darkfield_leds(argc, (char * *) argv); }
+int scan_full_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_sequence_individual_leds(argc, (char * *) argv); }
+int scan_brightfield_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_sequence_individual_brightfield_leds(argc, (char * *) argv); }
+int scan_darkfield_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_sequence_individual_darkfield_leds(argc, (char * *) argv); }
 
-int set_sequence_length_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.set_sequence_length(argc, (char * *) argv); }
-int set_sequence_value_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.set_sequence_value(argc, (char * *) argv); }
-int run_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_sequence(argc, (char * *) argv); }
-int print_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.print_sequence(argc, (char * *) argv); }
-int step_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.step_sequence(argc, (char * *) argv); }
-int restart_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.restart_sequence(argc, (char * *) argv); }
+int set_custom_sequence_length_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.set_custom_sequence_length(argc, (char * *) argv); }
+int set_custom_sequence_value_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.set_custom_sequence_value(argc, (char * *) argv); }
+int run_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_custom_sequence(argc, (char * *) argv); }
+int print_custom_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.print_custom_sequence(argc, (char * *) argv); }
+int step_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.step_custom_sequence(argc, (char * *) argv); }
+int restart_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.restart_custom_sequence(argc, (char * *) argv); }
 
 int trigger_func(CommandRouter *cmd, int argc, const char **argv) { if (argc == 1) return led_array.send_trigger_pulse(0, true); else if (argc == 2) return led_array.send_trigger_pulse(atoi(argv[1]), true); else return ERROR_ARGUMENT_COUNT;}
 int trigger_setup_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.trigger_setup(argc, (char * *) argv); }

--- a/illuminate/illuminate.ino
+++ b/illuminate/illuminate.ino
@@ -145,7 +145,6 @@ int print_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return
 int step_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.step_sequence(argc, (char * *) argv); }
 int restart_sequence_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.restart_sequence(argc, (char * *) argv); }
 
-
 int trigger_func(CommandRouter *cmd, int argc, const char **argv) { if (argc == 1) return led_array.send_trigger_pulse(0, true); else if (argc == 2) return led_array.send_trigger_pulse(atoi(argv[1]), true); else return ERROR_ARGUMENT_COUNT;}
 int trigger_setup_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.trigger_setup(argc, (char * *) argv); }
 int trigger_test_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.trigger_input_test(strtoul((char *) argv[0], NULL, 0)); }
@@ -167,7 +166,6 @@ int water_func(CommandRouter *cmd, int argc, const char **argv){ return led_arra
 int get_pn_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.print_part_number(argc, (char * *) argv); }
 int get_sn_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.print_serial_number(argc, (char * *) argv); }
 
-int run_fpm_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_sequence_fpm(argc, (char * *) argv); }
 int run_dpc_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.run_sequence_dpc(argc, (char * *) argv); }
 
 int set_baud_rate_func(CommandRouter *cmd, int argc, const char **argv){ return led_array.set_sclk_baud_rate(argc, (char * *) argv); }

--- a/illuminate/ledarray.h
+++ b/illuminate/ledarray.h
@@ -48,10 +48,7 @@ class LedArray {
     int run_demo();    // Run a demo which tests the functions below
 
     // Pattern commands
-    int draw_led_list(uint16_t argc, char ** argv);          // Draw a list of LEDs (or just 1)
-    int scan_brightfield_leds(uint16_t argc, char ** argv);  // Scan brightfield LEDs
-    int scan_darkfield_leds(uint16_t argc, char ** argv);  // Scan brightfield LEDs
-    int scan_all_leds(uint16_t argc, char ** argv);
+    int draw_led_list(uint16_t argc, char ** argv);
     int draw_dpc(uint16_t argc, char ** argv);
     int draw_brightfield(uint16_t argc, char ** argv);;
     int draw_half_annulus(uint16_t argc, char * *argv);
@@ -90,15 +87,19 @@ class LedArray {
     int set_max_current_enforcement(uint16_t argc, char ** argv);
     int set_max_current_limit(uint16_t argc, char ** argv);
 
-    // Sequencing
-    int run_sequence(uint16_t argc, char ** argv);
+    // Custom sequences
+    int run_custom_sequence(uint16_t argc, char ** argv);
+    int step_custom_sequence(uint16_t argc, char ** argv);
+    int set_custom_sequence_value(uint16_t argc, char ** argv);
+    int print_custom_sequence(uint16_t argc, char ** argv);
+    int restart_custom_sequence(uint16_t argc, char ** argv);
+    int set_custom_sequence_length(uint16_t argc, char ** argv);
+
+    // Pre-defined sequences
     int run_sequence_dpc(uint16_t argc, char ** argv);
-    int run_sequence_fpm(uint16_t argc, char ** argv);
-    int step_sequence(uint16_t argc, char ** argv);
-    int set_sequence_value(uint16_t argc, char ** argv);
-    int print_sequence(uint16_t argc, char ** argv);
-    int restart_sequence(uint16_t argc, char ** argv);
-    int set_sequence_length(uint16_t argc, char ** argv);
+    int run_sequence_individual_leds(uint16_t argc, char ** argv);
+    int run_sequence_individual_brightfield_leds(uint16_t argc, char ** argv);
+    int run_sequence_individual_darkfield_leds(uint16_t argc, char ** argv);
 
     int print_part_number(uint16_t argc, char ** argv);
     int print_serial_number(uint16_t argc, char ** argv);
@@ -118,7 +119,7 @@ class LedArray {
     void not_implemented(const char * command_name);
     int draw_channel(uint16_t argc, char * *argv);
     int set_pin_order(uint16_t argc, char * *argv);
-    void scan_led_range(uint16_t delay_ms, float start_na, float end_na, bool print_indicies);
+    int scan_led_range(uint16_t delay_ms, float start_na, float end_na, bool print_indicies, uint16_t sequence_run_count);
 
     int print_mac_address();
     int set_sclk_baud_rate(uint16_t argc, char ** argv);
@@ -244,7 +245,6 @@ class LedArray {
 
     // timer variable
     static volatile uint16_t pattern_index;
-    static volatile uint16_t frame_index;
 
     // Command mode
     bool command_mode = COMMAND_MODE_LONG;


### PR DESCRIPTION
Updates the sequencing API to be consistent across `rdpc` , `scf`, `scb`, and `scd`, and removed `rfpm` which is redundant with `scf`.